### PR TITLE
Enable momentum scrolling on code blocks

### DIFF
--- a/src/components/BlogContent.tsx
+++ b/src/components/BlogContent.tsx
@@ -45,7 +45,7 @@ export function BlogContent({ post }: BlogContentProps) {
     };
 
     return !inline && match ? (
-      <div className="relative group overflow-x-auto">
+      <div className="relative group overflow-x-auto scrolling-touch">
         <button
           onClick={handleCopy}
           aria-label="Copy code"


### PR DESCRIPTION
## Summary
- ensure code block wrappers use touch scrolling for smoother overflow behavior on iOS

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: existing lint errors in unrelated files)*
- `npx eslint src/components/BlogContent.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689ba4c22e048333b8dc00b56b189554