### PR TITLE
refactor: remove debug logging

### DIFF
--- a/src/components/BlogLayout.tsx
+++ b/src/components/BlogLayout.tsx
@@ -12,9 +12,7 @@ export function BlogLayout() {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const [isMobile, setIsMobile] = useState(false);
   
-  console.log("BlogLayout rendering with postId:", postId);
   const post = postId ? blogPosts[postId] : blogPosts["ad-intro"];
-  console.log("Selected post:", post?.title);
 
   useEffect(() => {
     const checkMobile = () => {

--- a/src/components/Comments.tsx
+++ b/src/components/Comments.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
@@ -23,13 +23,8 @@ export function Comments({ postId }: CommentsProps) {
   const [message, setMessage] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  useEffect(() => {
-    fetchComments();
-  }, [postId]);
-
-  const fetchComments = async () => {
+  const fetchComments = useCallback(async () => {
     try {
-      console.log('Fetching comments for post:', postId);
       const { data, error } = await supabase
         .from('comments')
         .select('*')
@@ -40,12 +35,15 @@ export function Comments({ postId }: CommentsProps) {
         console.error('Error fetching comments:', error);
         throw error;
       }
-      console.log('Fetched comments:', data);
       setComments(data || []);
     } catch (error) {
       console.error('Error fetching comments:', error);
     }
-  };
+  }, [postId]);
+
+  useEffect(() => {
+    fetchComments();
+  }, [fetchComments]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -58,8 +56,6 @@ export function Comments({ postId }: CommentsProps) {
     setIsSubmitting(true);
     
     try {
-      console.log('Submitting comment:', { post_id: postId, name: name.trim(), message: message.trim() });
-      
       const { data, error } = await supabase
         .from('comments')
         .insert({
@@ -74,7 +70,6 @@ export function Comments({ postId }: CommentsProps) {
         throw error;
       }
       
-      console.log('Comment inserted successfully:', data);
       toast.success("Comment posted successfully!");
       setName("");
       setMessage("");

--- a/src/components/LanguageToggle.tsx
+++ b/src/components/LanguageToggle.tsx
@@ -1,5 +1,21 @@
 import { useEffect } from "react";
 
+declare global {
+  interface Window {
+    googleTranslateElementInit?: () => void;
+    google?: {
+      translate: {
+        TranslateElement: {
+          new (options: Record<string, unknown>, elementId: string): void;
+          InlineLayout: {
+            SIMPLE: unknown;
+          };
+        };
+      };
+    };
+  }
+}
+
 interface LanguageToggleProps {
   variant?: "mobile" | "desktop";
 }
@@ -10,25 +26,25 @@ export function LanguageToggle({ variant = "desktop" }: LanguageToggleProps) {
     const addGoogleTranslateScript = () => {
       // Check if script already exists
       if (document.getElementById('google-translate-script')) {
-        console.log('Google Translate script already exists');
         return;
       }
-
-      console.log('Loading Google Translate script...');
       
       // Initialize Google Translate function first
-      (window as any).googleTranslateElementInit = function() {
-        console.log('Initializing Google Translate widget...');
+      window.googleTranslateElementInit = function() {
         try {
-          new (window as any).google.translate.TranslateElement({
-            pageLanguage: 'en',
-            includedLanguages: 'en,ta,hi,fr,es,de,it,pt,ru,ja,ko,zh,ar',
-            layout: (window as any).google.translate.TranslateElement.InlineLayout.SIMPLE,
-            multilanguagePage: true,
-            gaTrack: true,
-            gaId: 'UA-XXXXX-X'
-          }, 'google_translate_element');
-          console.log('Google Translate widget initialized successfully');
+          if (window.google?.translate) {
+            new window.google.translate.TranslateElement(
+              {
+                pageLanguage: 'en',
+                includedLanguages: 'en,ta,hi,fr,es,de,it,pt,ru,ja,ko,zh,ar',
+                layout: window.google.translate.TranslateElement.InlineLayout.SIMPLE,
+                multilanguagePage: true,
+                gaTrack: true,
+                gaId: 'UA-XXXXX-X'
+              },
+              'google_translate_element'
+            );
+          }
         } catch (error) {
           console.error('Error initializing Google Translate:', error);
         }
@@ -40,9 +56,6 @@ export function LanguageToggle({ variant = "desktop" }: LanguageToggleProps) {
       script.async = true;
       script.defer = true;
       
-      script.onload = () => {
-        console.log('Google Translate script loaded successfully');
-      };
       
       script.onerror = (error) => {
         console.error('Error loading Google Translate script:', error);


### PR DESCRIPTION
## Summary
- remove leftover `console.log` calls from blog layout and other components
- cleanup comments logic and eliminate debug logging
- type Google Translate hook and drop debug console output

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: 31 problems, 24 errors, 7 warnings)
- `npx eslint src/components/BlogLayout.tsx src/components/Comments.tsx src/components/LanguageToggle.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689ba4bd9b848333a69a36158c189dd6