### PR TITLE
fix(css): Add horizontal scroll to code blocks on mobile

### DIFF
--- a/src/components/BlogContent.tsx
+++ b/src/components/BlogContent.tsx
@@ -45,7 +45,7 @@ export function BlogContent({ post }: BlogContentProps) {
     };
 
     return !inline && match ? (
-      <div className="relative group overflow-x-auto">
+      <div className="relative group overflow-x-auto w-full">
         <button
           onClick={handleCopy}
           aria-label="Copy code"
@@ -56,7 +56,7 @@ export function BlogContent({ post }: BlogContentProps) {
         <SyntaxHighlighter
           style={tomorrow}
           language={match[1]}
-          className="overflow-x-auto text-sm pr-8"
+          className="overflow-x-auto text-sm pr-8 w-full"
           {...restProps}
         >
           {codeString}


### PR DESCRIPTION
On smaller screens, code blocks with long lines would overflow the container and cause the entire page to scroll horizontally, breaking the mobile layout.

This was caused by the container of the code block not having a constrained width, allowing it to grow to the full width of its content.

This fix applies `w-full` (width: 100%) to the wrapping container of the `SyntaxHighlighter` component in `BlogContent.tsx`. This constrains the container to the width of its parent element. The existing `overflow-x-auto` property on this container now correctly creates a horizontal scrollbar for any code block that is wider than the container, without affecting the overall page layout.